### PR TITLE
WebFlow Voter List Fix

### DIFF
--- a/src/roundmap.js
+++ b/src/roundmap.js
@@ -66,7 +66,7 @@ const RoundMap = async (stateObj) => {
             const bStoryID = value["b-story"];
             const updatedOn = value["updated-on"];
             const matchNewDay = !isToday(updatedOn, today);
-            const voters = (value.hasOwnProperty("voters") && matchNewDay) ? [] : value.voters;
+            const voters = (value.hasOwnProperty("voters") || !matchNewDay) ? value.voters : [];
             roundMap.matchups[key] = {
                 "a-story": aStoryID,
                 "b-story": bStoryID,
@@ -110,7 +110,7 @@ module.exports.build = () => datastore.runQuery(activeStateQuery)
 
 /**
  * @param {number} matchUpId
- * @param {Set<any>} voterList
+ * @param {any[]} voterList
  * @param {Date} updatedOn
  * @return {Promise}
  */

--- a/src/routes/vote.js
+++ b/src/routes/vote.js
@@ -30,16 +30,16 @@ module.exports = async (req, res, next) => {
                 return res.send({data: {message: "You've already voted for this story."}});
             } else {
                 voterIDs.add(uid)
-                voterIDs = [...voterIDs];
+                const voters = [...voterIDs];
                 let fields = {
-                    voters: voterIDs.toString(),
+                    voters: voters.toString(),
                 }
                 fields[`${slot}-votes`] = ++matchUpObj[`${slot}-votes`]
                 const patchResponse = await MatchupsCollection.patchLiveItem(matchupID, {
                     fields: fields
                 });
-                logger.debug(patchResponse);
-                return RoundMap.update(matchupID, voterIDs, new Date(patchResponse["updated-on"])).then(() => {
+                logger.debug(JSON.stringify(patchResponse));
+                return RoundMap.update(matchupID, voters, new Date(patchResponse["updated-on"])).then(() => {
                     logger.info(`Voter: ${uid}, Story: ${storyID}`);
                     return res.send({data: {message: "vote successful"}});
                 }).catch(error => logger.error(error))


### PR DESCRIPTION
This is a fix for the bug where WebFlow's copy of a match-up's voter list doesn't get purged when a new day is detected.